### PR TITLE
Fix support for SHARE env variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,7 +17,7 @@ fi
 ## check if the first argument passed in is expose and if it's the only one
 if [ "$#" = 1 ] && [ "$1" = "expose" ]; then
   if [ -n "${SHARE}" ]; then
-      set -- "$@" "${SHARE}"
+      set -- "$@" "share" "${SHARE}"
     fi
   if [ -n "${SUBDOMAIN}" ]; then
     set -- "$@" "--subdomain=${SUBDOMAIN}"


### PR DESCRIPTION
I think you want to use the SHARE env variable to specify the URL to share, right? 

This needs to be prefixed with "share". Unfortunately just setting SHARE="share http://url" does not work.

This PR prefixes the SHARE env variable with "share" in the entrypoint script.